### PR TITLE
Add note in Contact about back-end

### DIFF
--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -73,6 +73,7 @@ function Contact() {
   return (
     <div>
       <h1 style={{ color: '#D58DF6', fontSize: '3rem', fontFamily: 'Courier New, sans-serif'  }}>Contact</h1>
+      <p style={{ marginTop: '20px' }}>Currently, this application does not contain back-end functionality. It will be added soon! Please contact me at aebellanger@yahoo.com or at 910-334-0282.</p>
       <Form onSubmit={handleFormSubmit}>
         <Form.Group className="mb-3">
           <Form.Label>Name</Form.Label>


### PR DESCRIPTION
This commit adds a note in the Contact section directing users to contact me by email or phone as the back-end functionality hasn't been set up that would allow the form to send user input to me yet.